### PR TITLE
Increase database connection pool size

### DIFF
--- a/db.rb
+++ b/db.rb
@@ -6,6 +6,7 @@ def setup_db_connection
   ActiveRecord::Base.establish_connection(
     adapter: :postgresql,
     host: ENV.fetch('DB_HOST', 'localhost'),
+    pool: ENV.fetch('DB_POOL', 50),
     database: ENV.fetch('DB_NAME', 'postgres'),
     username: ENV.fetch('DB_USERNAME', 'postgres'),
     password: ENV.fetch('DB_PASSWORD', 'postgres'),


### PR DESCRIPTION
- We were seeing errors about:

  ```
  2019-07-01 09:29:24 - ActiveRecord::ConnectionTimeoutError - could not
  obtain a connection from the pool within 5.000 seconds (waited 5.000
  seconds); all pooled connections were in use:
  ```
- This is live - we `docker exec`ed into the container and made the
  changes, the app is back.